### PR TITLE
Simplify h5_path_exists using Group.__contains__

### DIFF
--- a/MenuItemImportMctRecon_fabaf8b8b65611eebed60242ac150006.py
+++ b/MenuItemImportMctRecon_fabaf8b8b65611eebed60242ac150006.py
@@ -79,12 +79,8 @@ def h5_path_exists(filepath: str, h5_path: str) -> bool:
     bool
         True iff the path exists
     """
-    try:
-        with h5py.File(filepath, 'r') as f:
-            _data = f[h5_path]
-        return True
-    except KeyError:
-        return False
+    with h5py.File(filepath, 'r') as f:
+        return h5_path in f
 
 
 def error_dialog(title: str, text: str) -> None:


### PR DESCRIPTION
Every `File` is also a `Group` representing the root group in the file, so [`Group.__contains__`](https://docs.h5py.org/en/stable/high/group.html#h5py.Group.__contains__) is available and `h5_path in f` can be used to check if the path exists within the file.

@gazzar 